### PR TITLE
add: delay between iteration of the 'start' func

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup
 from cli import log
 
 SLEEP_TIME = 5
+SLEEP_TIME_TO_AVOID_TOO_MANY_REQUEST_ERRORS = 60
 SLEEP_TIME_NO_GAMES = 120
 SLEEP_TIME_NO_POINTS = 900
 
@@ -201,6 +202,8 @@ class SteamGifts:
             log(f"🌸 [Special Mode] Checking for new games...", "green")
             self.filter_url = FILTER_URLS["All"]
         else:
+            log(f"🌸 [Special Mode] Waiting to avoid being blocked...", "green")
+            time.sleep(SLEEP_TIME_TO_AVOID_TOO_MANY_REQUEST_ERROR)
             self.start()
 
         self.special_mode_stage += 1


### PR DESCRIPTION
After ‘special_mode_stage’ reached 8, the program would start the ‘start’ func all over again, causing an incessant stream of requests to the site. Which, in all likelihood, caused the “Too Many Requests” error or the site not letting the user's IP through due to the same error. By adding a one minute delay, this stopped. (I introduced a new variable to denote the number of seconds ‘SLEEP_TIME_TO_AVOID_TOO_MANY_REQUEST_ERRORS’)